### PR TITLE
feat(ci): add gpio2mqtt dispatch trigger workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
     types:
       - published
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI", "gpio2mqtt Trigger"]
     branches: [main]
     types:
       - completed

--- a/.github/workflows/gpio2mqtt-trigger.yaml
+++ b/.github/workflows/gpio2mqtt-trigger.yaml
@@ -11,6 +11,8 @@ jobs:
   process:
     name: Process gpio2mqtt build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Log event details
         run: |

--- a/.github/workflows/gpio2mqtt-trigger.yaml
+++ b/.github/workflows/gpio2mqtt-trigger.yaml
@@ -1,0 +1,55 @@
+---
+name: gpio2mqtt Trigger
+
+# yamllint disable-line rule:truthy
+on:
+  repository_dispatch:
+    types:
+      - gpio2mqtt-build
+
+jobs:
+  process:
+    name: Process gpio2mqtt build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log event details
+        run: |
+          echo "## gpio2mqtt Build Event" >> $GITHUB_STEP_SUMMARY
+          echo "- Version: ${{ github.event.client_payload.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Tag: ${{ github.event.client_payload.tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Is Release: ${{ github.event.client_payload.is_release }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Is Prerelease: ${{ github.event.client_payload.is_prerelease }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Source: ${{ github.event.client_payload.source_repo }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create draft release
+        if: github.event.client_payload.is_release == true && github.event.client_payload.is_prerelease != true
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: "Update gpio2mqtt to ${{ github.event.client_payload.version }}"
+          tag_name: "v${{ github.event.client_payload.version }}"
+          body: |
+            ## Changes
+            - Updated gpio2mqtt binary to version ${{ github.event.client_payload.version }}
+
+            ## gpio2mqtt Release
+            - Source: https://github.com/${{ github.event.client_payload.source_repo }}
+            - Tag: ${{ github.event.client_payload.tag }}
+          prerelease: false
+
+      - name: Create draft prerelease
+        if: github.event.client_payload.is_prerelease == true
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          name: "Update gpio2mqtt to ${{ github.event.client_payload.version }} (beta)"
+          tag_name: "v${{ github.event.client_payload.version }}"
+          body: |
+            ## Changes
+            - Updated gpio2mqtt binary to version ${{ github.event.client_payload.version }}
+
+            ## gpio2mqtt Prerelease
+            - Source: https://github.com/${{ github.event.client_payload.source_repo }}
+            - Tag: ${{ github.event.client_payload.tag }}
+            - This is a beta release for testing
+          prerelease: true

--- a/.github/workflows/gpio2mqtt-trigger.yaml
+++ b/.github/workflows/gpio2mqtt-trigger.yaml
@@ -15,14 +15,22 @@ jobs:
       contents: write
     steps:
       - name: Log event details
+        env:
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          PAYLOAD_TAG: ${{ github.event.client_payload.tag }}
+          PAYLOAD_IS_RELEASE: ${{ github.event.client_payload.is_release }}
+          PAYLOAD_IS_PRERELEASE: ${{ github.event.client_payload.is_prerelease }}
+          PAYLOAD_SOURCE_REPO: ${{ github.event.client_payload.source_repo }}
         run: |
-          echo "## gpio2mqtt Build Event" >> $GITHUB_STEP_SUMMARY
-          echo "- Version: ${{ github.event.client_payload.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Tag: ${{ github.event.client_payload.tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Is Release: ${{ github.event.client_payload.is_release }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Is Prerelease: ${{ github.event.client_payload.is_prerelease }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Source: ${{ github.event.client_payload.source_repo }}" >> $GITHUB_STEP_SUMMARY
+          echo "## gpio2mqtt Build Event" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Version: ${PAYLOAD_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tag: ${PAYLOAD_TAG}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Is Release: ${PAYLOAD_IS_RELEASE}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Is Prerelease: ${PAYLOAD_IS_PRERELEASE}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Source: ${PAYLOAD_SOURCE_REPO}" >> "$GITHUB_STEP_SUMMARY"
 
+      # Note: If both is_release and is_prerelease are true, only prerelease is created
+      # This is intentional - prereleases take precedence
       - name: Create draft release
         if: github.event.client_payload.is_release == true && github.event.client_payload.is_prerelease != true
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Add `gpio2mqtt-trigger.yaml` workflow to handle `repository_dispatch` events from gpio2mqtt repository
- Update `deploy.yaml` to trigger on `gpio2mqtt Trigger` workflow completion

## Behavior

| Event | Draft Created | Published Channel |
|-------|---------------|-------------------|
| Dev build (is_release=false) | No | edge |
| Prerelease (is_prerelease=true) | Draft prerelease | beta |
| Release (is_release=true) | Draft release | stable |

## How it works

1. gpio2mqtt repository sends `repository_dispatch` event with type `gpio2mqtt-build`
2. `gpio2mqtt-trigger` workflow processes the event:
   - Logs event details to job summary
   - Creates draft release/prerelease if applicable
3. `deploy` workflow triggers via `workflow_run` and builds addon with `BINARY_VERSION=dev`
4. For releases: manual review and publish of draft triggers deploy to beta/stable

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test dispatch event handling (can be tested via `gh api` with PAT)
- [ ] Verify draft releases are created correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automation for gpio2mqtt-driven releases and ties it into the deploy pipeline.
> 
> - Adds `gpio2mqtt-trigger.yaml` to handle `repository_dispatch` (`gpio2mqtt-build`), log payload details, and create draft releases/prereleases via `softprops/action-gh-release` based on `is_release`/`is_prerelease`
> - Updates `deploy.yaml` to also trigger on completion of the `gpio2mqtt Trigger` workflow (in addition to `CI`) on `main`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1216cc3f371be463516bda4a0165ef4d59a60979. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->