### PR TITLE
fix(config): add legacy_mqttio compatibility settings

### DIFF
--- a/jethub-mqtt-io/config.yaml
+++ b/jethub-mqtt-io/config.yaml
@@ -23,6 +23,7 @@ options:
   mqtt:
     client_id: jethub-mqtt-io
     topic_prefix: jethub-mqtt-io
+    legacy_mqttio: true
     keepalive: 60
     qos: 1
 
@@ -38,5 +39,6 @@ schema:
     password: str?
     client_id: str
     topic_prefix: str
+    legacy_mqttio: bool
     keepalive: int(5,3600)?
     qos: int(0,2)?

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d1-module.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d1-module.yaml
@@ -16,7 +16,6 @@ mqtt:
   password: XXXXXXXXXXXX
   client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
-  legacy_mqttio: true
   # Birth/LWT messages
   status_payload_running: available
   status_payload_stopped: unavailable

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d1-module.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d1-module.yaml
@@ -14,7 +14,9 @@ mqtt:
   port: 1883
   user: XXXXXXXXXXXX
   password: XXXXXXXXXXXX
+  client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
+  legacy_mqttio: true
   # Birth/LWT messages
   status_payload_running: available
   status_payload_stopped: unavailable

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d1.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d1.yaml
@@ -15,7 +15,6 @@ mqtt:
   password: XXXXXXXXXXXX
   client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
-  legacy_mqttio: true
   # Birth/LWT messages
   status_payload_running: available
   status_payload_stopped: unavailable

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d1.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d1.yaml
@@ -13,7 +13,9 @@ mqtt:
   port: 1883
   user: XXXXXXXXXXXX
   password: XXXXXXXXXXXX
+  client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
+  legacy_mqttio: true
   # Birth/LWT messages
   status_payload_running: available
   status_payload_stopped: unavailable

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d2-module.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d2-module.yaml
@@ -17,7 +17,9 @@ mqtt:
   port: 1883
   user: XXXXXXXXXXXX
   password: XXXXXXXXXXXX
+  client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
+  legacy_mqttio: true
   # Birth/LWT messages for Home Assistant availability
   status_payload_running: available # Birth message (on connect)
   status_payload_stopped: unavailable # Graceful shutdown

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d2-module.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d2-module.yaml
@@ -19,7 +19,6 @@ mqtt:
   password: XXXXXXXXXXXX
   client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
-  legacy_mqttio: true
   # Birth/LWT messages for Home Assistant availability
   status_payload_running: available # Birth message (on connect)
   status_payload_stopped: unavailable # Graceful shutdown

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d2.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d2.yaml
@@ -17,7 +17,6 @@ mqtt:
   password: XXXXXXXXXXXX
   client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
-  legacy_mqttio: true
   # Birth/LWT messages for Home Assistant availability
   status_payload_running: available # Birth message (on connect)
   status_payload_stopped: unavailable # Graceful shutdown

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d2.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-d2.yaml
@@ -15,7 +15,9 @@ mqtt:
   port: 1883
   user: XXXXXXXXXXXX
   password: XXXXXXXXXXXX
+  client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
+  legacy_mqttio: true
   # Birth/LWT messages for Home Assistant availability
   status_payload_running: available # Birth message (on connect)
   status_payload_stopped: unavailable # Graceful shutdown

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-h1-module.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-h1-module.yaml
@@ -17,7 +17,6 @@ mqtt:
   password: XXXXXXXXXXXX
   client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
-  legacy_mqttio: true
   # Birth/LWT messages
   status_payload_running: available
   status_payload_stopped: unavailable

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-h1-module.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-h1-module.yaml
@@ -15,7 +15,9 @@ mqtt:
   port: 1883
   user: XXXXXXXXXXXX
   password: XXXXXXXXXXXX
+  client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
+  legacy_mqttio: true
   # Birth/LWT messages
   status_payload_running: available
   status_payload_stopped: unavailable

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-h1.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-h1.yaml
@@ -15,7 +15,6 @@ mqtt:
   password: XXXXXXXXXXXX
   client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
-  legacy_mqttio: true
   # Birth/LWT messages
   status_payload_running: available
   status_payload_stopped: unavailable

--- a/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-h1.yaml
+++ b/jethub-mqtt-io/rootfs/etc/gpio2mqtt/configs/jethub-h1.yaml
@@ -13,7 +13,9 @@ mqtt:
   port: 1883
   user: XXXXXXXXXXXX
   password: XXXXXXXXXXXX
+  client_id: jethub-mqtt-io
   topic_prefix: jethub-mqtt-io
+  legacy_mqttio: true
   # Birth/LWT messages
   status_payload_running: available
   status_payload_stopped: unavailable

--- a/jethub-mqtt-io/rootfs/usr/local/bin/entrypoint.sh
+++ b/jethub-mqtt-io/rootfs/usr/local/bin/entrypoint.sh
@@ -119,6 +119,7 @@ generate_config() {
     export GPIO2MQTT_MQTT_PASS="$MQTT_PASS"
     export GPIO2MQTT_MQTT_CLIENT_ID="$MQTT_CLIENT_ID"
     export GPIO2MQTT_MQTT_TOPIC_PREFIX="$MQTT_TOPIC_PREFIX"
+    export GPIO2MQTT_MQTT_LEGACY_MQTTIO="$MQTT_LEGACY_MQTTIO"
     export GPIO2MQTT_MQTT_KEEPALIVE="$MQTT_KEEPALIVE"
     export GPIO2MQTT_MQTT_QOS="$MQTT_QOS"
 
@@ -164,6 +165,7 @@ mqtt_user = os.environ.get('GPIO2MQTT_MQTT_USER', '')
 mqtt_pass = os.environ.get('GPIO2MQTT_MQTT_PASS', '')
 mqtt_client_id = os.environ.get('GPIO2MQTT_MQTT_CLIENT_ID', '')
 mqtt_topic_prefix = os.environ.get('GPIO2MQTT_MQTT_TOPIC_PREFIX', '')
+mqtt_legacy_mqttio = os.environ.get('GPIO2MQTT_MQTT_LEGACY_MQTTIO', 'true')
 mqtt_keepalive = os.environ.get('GPIO2MQTT_MQTT_KEEPALIVE', '')
 mqtt_qos = os.environ.get('GPIO2MQTT_MQTT_QOS', '')
 
@@ -202,6 +204,9 @@ try:
         config['mqtt']['keepalive'] = int(mqtt_keepalive)
     if mqtt_qos:
         config['mqtt']['qos'] = int(mqtt_qos)
+
+    # Set legacy_mqttio boolean
+    config['mqtt']['legacy_mqttio'] = mqtt_legacy_mqttio.lower() == 'true'
 
     with open(config_path, 'w') as f:
         yaml.dump(config, f, Dumper=SafeDumperPreserveStrings, default_flow_style=False, allow_unicode=True)
@@ -244,6 +249,7 @@ main() {
     CUSTOM_CONFIG=$(get_option "custom_config" "")
     MQTT_CLIENT_ID=$(get_nested_option "mqtt.client_id" "jethub-mqtt-io")
     MQTT_TOPIC_PREFIX=$(get_nested_option "mqtt.topic_prefix" "jethub-mqtt-io")
+    MQTT_LEGACY_MQTTIO=$(get_nested_option "mqtt.legacy_mqttio" "true")
 
     # Manual MQTT settings (optional)
     MANUAL_MQTT_HOST=$(get_nested_option "mqtt.host" "")


### PR DESCRIPTION
## Summary

Add `client_id` and `legacy_mqttio: true` to all gpio2mqtt configs for seamless migration from mqtt-io.

## Changes

All 6 config files updated:
- jethub-d1.yaml
- jethub-d1-module.yaml
- jethub-d2.yaml
- jethub-d2-module.yaml
- jethub-h1.yaml
- jethub-h1-module.yaml

## Why

For `legacy_mqttio: true` mode, gpio2mqtt now requires `client_id` to generate correct:
- `unique_id`: `{client_id}_{module}_{input|output}_{name}`
- `discovery_topic`: `{prefix}/{component}/{client_id}/{name}/config`

This ensures no entity duplication in Home Assistant when migrating from mqtt-io.

## Test plan

- [ ] Verify addon builds successfully
- [ ] Test on JetHub device with migration from mqtt-io

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Enable legacy mqtt-io compatibility in gpio2mqtt**
> 
> - Add `mqtt.legacy_mqttio: true` default and schema to `config.yaml`; expose and read it in `entrypoint.sh`
> - Ensure `mqtt.client_id: jethub-mqtt-io` is present in all six gpio2mqtt config templates (D1/D2/H1 and module variants)
> - Update `entrypoint.sh` to export/read `MQTT_LEGACY_MQTTIO` and set `mqtt.legacy_mqttio` (bool) in generated YAML via Python helper
> - No functional changes outside MQTT config handling; focuses on HA discovery/ID stability during migration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe5c94f8ad2b203a419ee7716e98ca07493e2d9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->